### PR TITLE
Update service name in DEPLOY.md

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -316,13 +316,13 @@ If using Cloudflare, configure instead the edge and origin certificates in dashb
 Now you can start Conduit with:
 
 ```bash
-$ sudo systemctl start conduit
+$ sudo systemctl start matrix-conduit
 ```
 
 Set it to start automatically when your system boots with:
 
 ```bash
-$ sudo systemctl enable conduit
+$ sudo systemctl enable matrix-conduit
 ```
 
 ## How do I know it works?


### PR DESCRIPTION
The documentation refers to the service as `conduit` but dpkg says otherwise as it has created the service named `matrix-conduit`.
I have edited `DEPLOY.md` to reflect that change.

```
Setting up matrix-conduit (0.6.0) ...
Adding system user for the Conduit Matrix homeserver
Created symlink /etc/systemd/system/multi-user.target.wants/matrix-conduit.service → /lib/systemd/system/matrix-conduit.service.
```